### PR TITLE
Fix Memory Leak

### DIFF
--- a/src/main/java/mod/maxbogomol/wizards_reborn/mixin/common/BowItemMixin.java
+++ b/src/main/java/mod/maxbogomol/wizards_reborn/mixin/common/BowItemMixin.java
@@ -32,5 +32,6 @@ public class BowItemMixin {
     public void wizards_reborn$releaseUsing(ItemStack stack, Level level, LivingEntity entityLiving, int timeLeft, CallbackInfo ci) {
         EagleShotArcaneEnchantment.onBowShot(this.wizards_reborn$abstractArrow, stack, level, entityLiving, timeLeft);
         SplitArcaneEnchantment.onBowShot(this.wizards_reborn$abstractArrow, stack, level, entityLiving, timeLeft);
+        this.wizards_reborn$abstractArrow = null;
     }
 }


### PR DESCRIPTION
In BowItemMixin, set the injected member to "null" after using it so it doesn't get retained permanently until another arrow is shot.