### PR TITLE
Replace System.out.println with logger

### DIFF
--- a/src/main/java/mod/maxbogomol/wizards_reborn/common/command/WizardsRebornCommand.java
+++ b/src/main/java/mod/maxbogomol/wizards_reborn/common/command/WizardsRebornCommand.java
@@ -5,6 +5,7 @@ import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import mod.maxbogomol.wizards_reborn.WizardsReborn;
 import mod.maxbogomol.wizards_reborn.api.arcaneenchantment.ArcaneEnchantment;
 import mod.maxbogomol.wizards_reborn.api.arcaneenchantment.ArcaneEnchantmentUtil;
 import mod.maxbogomol.wizards_reborn.api.knowledge.Knowledge;
@@ -835,10 +836,10 @@ public class WizardsRebornCommand {
             for (Monogram monogram : startMap) {
                 string = string + " WizardsReborn." + Component.translatable(monogram.getTranslatedName()).getString().toUpperCase() + "_MONOGRAM, ";
             }
-            System.out.println(string);
+            WizardsReborn.LOGGER.info(string);
             for (Monogram monogram : monograms.keySet()) {
                 string = " new ResearchMonogramEntry(WizardsReborn." + Component.translatable(monogram.getTranslatedName()).getString().toUpperCase() + "_MONOGRAM, " + String.valueOf(monograms.get(monogram)) + "),";
-                System.out.println(string);
+                WizardsReborn.LOGGER.info(string);
             }
         }
 


### PR DESCRIPTION
Hi! Just a quick code cleanup PR. I noticed some leftover System.out.println calls in WizardsRebornCommand.java used during development/debugging for the research commands. I went ahead and replaced them with WizardsReborn.LOGGER.info so the messages correctly format and integrate with the server console's standard logging framework (Log4j/SLF4J).

Cheers!